### PR TITLE
DE3038: Silence some warnings from BBB release builds of lua.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ include $(REPO_ROOT)/build-internal/makefile.d/base.mk
 
 LUA_FILES = $(shell find src -type f)
 
+CFLAGS="-Wno-array-bounds"
+
 $(OUTPUT_DIR): $(LUA_FILES)
 	mkdir -p $(OUTPUT_DIR)
 	cp -R src/* $(OUTPUT_DIR)
-	cd $(OUTPUT_DIR) && make posix
+	cd $(OUTPUT_DIR) && $(MAKE) MYCFLAGS=$(CFLAGS) posix
 
 all: $(OUTPUT_DIR)
 


### PR DESCRIPTION
Defect [here](https://rally1.rallydev.com/#/3835160186d/detail/defect/45992807818). This just silences some compiler spew when building lua for `bbb-release`.

Before, we'd get a few screens of this:

```
lobject.c:160:18: warning: array index 3 is past the end of the array (which contains 3 elements) [-Warray-bounds]
  if (strpbrk(s, "nN"))  /* reject 'inf' and 'nan' */
      ~~~~~~~~~~~^~~~~
/usr/arm-linux-gnueabihf/include/bits/string2.h:1075:25: note: expanded from macro 'strpbrk'
                  : (((const char *) (accept))[3] == '\0'                     \
```
